### PR TITLE
composer 1.0.0-alpha9 doesn't support space

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "This package allows you to cache your routes definitions, thereby speeding up each request.",
     "keywords": ["laravel", "route", "routes", "cache", "caching", "performance"],
     "require": {
-        "laravel/framework": ">=4.1 <4.3"
+        "laravel/framework": ">=4.1,<4.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4"


### PR DESCRIPTION
I made a mistake on #6. Composer [1.0.0-alpha9](https://github.com/composer/composer/blob/1.0.0-alpha9/doc/01-basic-usage.md) doesn't even support space on range constraint. Next time I will not check getcomposer.org but check the target version doc on github instead. Will test more next time before making pull request.
